### PR TITLE
Restrict user creation to gerencia

### DIFF
--- a/controller/AuthController.php
+++ b/controller/AuthController.php
@@ -11,7 +11,8 @@ class AuthController
 
     public static function mostrarRegistro()
     {
-        include __DIR__.'/../view/auth/registro.php';
+        self::asegurarGerencia();
+        include __DIR__.'/../view/usuario/crear.php';
     }
 
     public static function procesarLogin()
@@ -37,6 +38,7 @@ class AuthController
 
     public static function procesarRegistro()
     {
+        self::asegurarGerencia();
         $nombre = $_POST['usuario'] ?? '';
         $clave  = $_POST['clave']   ?? '';
 
@@ -44,7 +46,22 @@ class AuthController
             header('Location: index.php?ruta=login&exito=1');
         } else {
             $error = 'Nombre ya registrado';
-            include __DIR__.'/../view/auth/registro.php';
+            include __DIR__.'/../view/usuario/crear.php';
+        }
+    }
+
+    /* ---------- helpers ---------- */
+
+    private static function asegurarGerencia()
+    {
+        if (session_status() === PHP_SESSION_NONE) session_start();
+        if (empty($_SESSION['usuario'])) {
+            header('Location: index.php?ruta=login');
+            exit;
+        }
+        if ($_SESSION['usuario']['rol'] !== 'gerencia') {
+            header('Location: index.php?ruta=menu&err=perm');
+            exit;
         }
     }
 }

--- a/index.php
+++ b/index.php
@@ -49,13 +49,13 @@ switch ($ruta) {
     case 'login':
         AuthController::mostrarLogin();
         break;
-    case 'registro':
+    case 'usuario_crear':
         AuthController::mostrarRegistro();
         break;
     case 'verificar_login':
         AuthController::procesarLogin();
         break;
-    case 'procesar_registro':
+    case 'usuario_guardar':
         AuthController::procesarRegistro();
         break;
     case 'menu':                 // pequeño menú después del login

--- a/view/index.php
+++ b/view/index.php
@@ -4,6 +4,7 @@ if (empty($_SESSION['usuario'])) {
     header('Location: index.php?ruta=login');
     exit;
 }
+$esGerencia = ($_SESSION['usuario']['rol'] === 'gerencia');
 ?>
 <!DOCTYPE html>
 <html lang="es">
@@ -20,8 +21,11 @@ if (empty($_SESSION['usuario'])) {
 <nav>
     <a href="index.php?ruta=producto_crear">➕ Crear producto</a> |
     <a href="index.php?ruta=producto_listar">📋 Ver productos</a> |
+    <?php if ($esGerencia): ?>
+        <a href="index.php?ruta=usuario_crear">➕ Nuevo usuario</a> |
+    <?php endif; ?>
     <a href="index.php?ruta=logout">⏻ Cerrar sesión</a>
-</nav> 
+</nav>
 </div>
 
 

--- a/view/usuario/crear.php
+++ b/view/usuario/crear.php
@@ -3,13 +3,13 @@
 <html lang="es">
 <head>
     <meta charset="UTF-8">
-    <title>Registro de usuario</title>
+    <title>Nuevo usuario</title>
     <link rel="stylesheet" href="/abc_inventario/assets/css/style.css">
 </head>
 <body>
 <?php include __DIR__.'/../templates/header.php'; ?>
 <div class="card form-centered">
-    <h2>Registrarse</h2>
+    <h2>Crear usuario</h2>
     <form method="POST" action="index.php?ruta=usuario_guardar">
     <label>Usuario
         <input type="text" name="usuario" required>
@@ -17,7 +17,7 @@
     <label>Contraseña
         <input type="password" name="clave" required>
     </label><br>
-    <button type="submit">Crear cuenta</button>
+    <button type="submit">Crear usuario</button>
 </form>
 </div>
 


### PR DESCRIPTION
## Summary
- restrict registration access in `AuthController`
- route `usuario_crear` and `usuario_guardar` to protected methods
- show a "Nuevo usuario" link for gerencia only
- add a dedicated view for creating users
- adjust original registration page action

## Testing
- `php -l controller/AuthController.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685c7b37b584832cb710a1e209a96197